### PR TITLE
Assign default exports on exports directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function getTranslatorComment(node) {
   return comments.length > 0 ? comments.join('\n') : null;
 }
 
-exports.default = function() {
+module.exports = function() {
   var currentFileName;
   var data;
   var relocatedComments = {};

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var babel = require('babel-core');
 
 var fs = require('fs');
-var plugin = require('../index.js').default;
+var plugin = require('../index.js');
 
 
 describe('babel-gettext-plugin', function() {


### PR DESCRIPTION
Fixes #4 

This pull request seeks to export module via `module.exports` instead of `exports.default`. In the former case this relies on the assignment of `exports.__esModule` to be inferred as a ES2015 import. This exists in the source repository but not in this fork:

https://github.com/jruchaud/babel-gettext-plugin/blob/e202dab9fc116c49beaccff8c5c89a1be88aac5f/index.js#L24