### PR TITLE
Generate filename dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options
   [ "babel-gettext-extractor", {
     "headers": <Object>,
     "functionNames": <Object>,
-    "fileName": <String>,
+    "fileName": <String|Function>,
     "baseDirectory": <String>,
     "stripTemplateLiteralIndent": <Boolean>
   }]
@@ -71,7 +71,28 @@ functionNames: {
 
 ### fileName ###
 
-The filename where the end result is placed.
+The filename where the end result is placed. If you supply a function, it will receive the current file babel is working
+on and you can return the full path to where you want to save your translation template for this particular file.
+
+example:
+```javascript
+[
+    require("babel-gettext-extractor"),
+    {
+        fileName: (file) => {
+            const sourceFile = file.opts.sourceFileName;
+            if (/^node_modules\//.test(sourceFile)) {
+                return false;
+            }
+            return sourceFile
+                .split(/[\/\\.]/)
+                .filter(name => !['src', 'packages', 'js'].includes(name))
+                .slice(0, 2)
+                .join('-') + '-template.pot';
+        },
+    },
+]
+```
 
 ### baseDirectory ###
 

--- a/index.js
+++ b/index.js
@@ -73,11 +73,20 @@ module.exports = function() {
 
       if (fileName !== currentFileName) {
         currentFileName = fileName;
-        data = {
-          charset: 'UTF-8',
-          headers: headers,
-          translations: { context: {} },
-        };
+        try {
+            const fileContents = fs.readFileSync(fileName, 'utf8');
+            data = gettextParser.mo.parse(fileContents);
+            data.headers = {
+                ...(data.headers || {}),
+                ...headers,
+            }
+        } catch (e) {
+            data = {
+                charset: 'UTF-8',
+                headers: headers,
+                translations: { context: {} },
+            };
+        }
 
         headers['plural-forms'] = headers['plural-forms']
           || DEFAULT_HEADERS['plural-forms'];

--- a/index.js
+++ b/index.js
@@ -74,18 +74,18 @@ module.exports = function() {
       if (fileName !== currentFileName) {
         currentFileName = fileName;
         try {
-            const fileContents = fs.readFileSync(fileName, 'utf8');
-            data = gettextParser.mo.parse(fileContents);
-            data.headers = {
-                ...(data.headers || {}),
-                ...headers,
-            }
+          const fileContents = fs.readFileSync(fileName, 'utf8');
+          data = gettextParser.mo.parse(fileContents);
+          data.headers = {
+            ...(data.headers || {}),
+            ...headers,
+          };
         } catch (e) {
-            data = {
-                charset: 'UTF-8',
-                headers: headers,
-                translations: { context: {} },
-            };
+          data = {
+            charset: 'UTF-8',
+            headers: headers,
+            translations: { context: {} },
+          };
         }
 
         headers['plural-forms'] = headers['plural-forms']

--- a/index.js
+++ b/index.js
@@ -63,6 +63,14 @@ module.exports = function() {
         base = base.match(/^(.*?)\/*$/)[1] + '/';
       }
 
+      if (typeof fileName === 'function') {
+        fileName = fileName(this.file);
+      }
+
+      if (!fileName) {
+        return;
+      }
+
       if (fileName !== currentFileName) {
         currentFileName = fileName;
         data = {

--- a/index.js
+++ b/index.js
@@ -73,14 +73,15 @@ module.exports = function() {
 
       if (fileName !== currentFileName) {
         currentFileName = fileName;
-        try {
+        if (fs.existsSync(fileName)) {
           const fileContents = fs.readFileSync(fileName, 'utf8');
-          data = gettextParser.mo.parse(fileContents);
+          data = gettextParser.po.parse(fileContents);
           data.headers = {
             ...(data.headers || {}),
             ...headers,
           };
-        } catch (e) {
+          data.translations.context = data.translations.context || {};
+        } else {
           data = {
             charset: 'UTF-8',
             headers: headers,

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,6 @@ var babel = require('babel-core');
 var fs = require('fs');
 var plugin = require('../index.js');
 
-
 describe('babel-gettext-extractor', function() {
   describe('#extract()', function() {
     it('Should return a result for simple code example', function() {
@@ -158,6 +157,24 @@ describe('babel-gettext-extractor', function() {
       assert(!!result);
       var content = fs.readFileSync('./test/react.po');
       assert(content.indexOf('msgid "title"') !== -1);
+    });
+
+    it('Should decide on a filename dynamically', function() {
+      const code = '_t("Dynamic Filenames")';
+
+      var result = babel.transform(code, {
+        plugins: [
+          [plugin, {
+            functionNames: {
+              _t: ['msgid'],
+            },
+            fileName: (file) => 'test/' + file.opts.sourceFileName + '-dynamic-filename.po',
+          }],
+        ],
+      });
+      assert(!!result);
+      var content = fs.readFileSync('./test/unknown-dynamic-filename.po');
+      assert(content.indexOf('msgid "Dynamic Filenames"') !== -1);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -176,5 +176,21 @@ describe('babel-gettext-extractor', function() {
       var content = fs.readFileSync('./test/unknown-dynamic-filename.po');
       assert(content.indexOf('msgid "Dynamic Filenames"') !== -1);
     });
+
+    it('Should skip a file if the dynamic filename is false', function() {
+      const code = '_t("Dynamic Filenames")';
+
+      var result = babel.transform(code, {
+        plugins: [
+          [plugin, {
+            functionNames: {
+              _t: ['msgid'],
+            },
+            fileName: () => false,
+          }],
+        ],
+      });
+      assert(!!result);
+    });
   });
 });


### PR DESCRIPTION
On large projects one might want to split translations based on the file they occur in. Think translation domains, for example. This change makes that possible

Fixes #10 