### PR TITLE
Add option to have code references use a universal slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var utils = require('./utils');
 var gettextParser = require('gettext-parser');
 var fs = require('fs');
+var path = require('path');
 
 var DEFAULT_FUNCTION_NAMES = {
   gettext: ['msgid'],
@@ -58,9 +59,10 @@ module.exports = function() {
       var functionNames = plugin.opts && plugin.opts.functionNames || DEFAULT_FUNCTION_NAMES;
       var fileName = plugin.opts && plugin.opts.fileName || DEFAULT_FILE_NAME;
       var headers = plugin.opts && plugin.opts.headers || DEFAULT_HEADERS;
-      var base = plugin.opts && plugin.opts.baseDirectory;
+      var base = plugin.opts && plugin.opts.baseDirectory && plugin.opts.baseDirectory.replace(/\\/g, '/');
+
       if (base) {
-        base = base.match(/^(.*?)\/*$/)[1] + '/';
+		base = base.match(/^(.*?)[\//]*$/)[1] + path.sep;
       }
 
       if (fileName !== currentFileName) {

--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ module.exports = function() {
       var fileName = plugin.opts && plugin.opts.fileName || DEFAULT_FILE_NAME;
       var headers = plugin.opts && plugin.opts.headers || DEFAULT_HEADERS;
       var base = plugin.opts && plugin.opts.baseDirectory;
+      var universalSlash = plugin.opts && plugin.opts.universalSlash;
+
       if (base) {
         base = base.match(/^(.*?)\/*$/)[1] + '/';
       }
@@ -115,6 +117,12 @@ module.exports = function() {
         var fn = this.file.opts.filename;
         if (base && fn && fn.substr(0, base.length) === base) {
           fn = fn.substr(base.length);
+        }
+
+        if (universalSlash === '/') {
+          fn = fn.replace(/\\/g, universalSlash)
+        } else if (universalSlash === '\\') {
+          fn = fn.replace(/\//g, universalSlash)
         }
 
         translate.comments = {


### PR DESCRIPTION
Add option to transform the windows style slashes to linux style slashes, and the other way around. This will generate consistent translation templates independent from the platform it's built on.