### PR TITLE
Sort reference line numbers as numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,9 @@ module.exports = function() {
           var refs = currentRef.split('\n');
           if (refs.indexOf(newRef) === -1) {
             refs.push(newRef);
-            context[translate.msgid].comments.reference = refs.sort().join('\n');
+            context[translate.msgid].comments.reference = refs
+              .sort(utils.compareReferenceLines)
+              .join('\n');
           }
         } else if (typeof translate.msgid !== 'undefined') {
           // Do not add translation if msgid is undefined.

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var babel = require('@babel/core');
 
 var fs = require('fs');
 var plugin = require('../index.js');
+var utils = require('../utils.js');
 
 describe('babel-gettext-extractor', function() {
   describe('#extract()', function() {
@@ -209,6 +210,118 @@ describe('babel-gettext-extractor', function() {
         ],
       });
       assert(!!result);
+    });
+  });
+});
+
+describe('utils', function() {
+  describe('#sortObjectKeysByRef()', function() {
+    it('Should sort source file line numbers as numbers', function() {
+      const unordered = {
+        a: { comments: { reference: 'path.js:20' } },
+        b: { comments: { reference: 'path.js:100' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should read line number from reference after the last colon', function() {
+      const unordered = {
+        a: { comments: { reference: 'path:with-colon.js:20' } },
+        b: { comments: { reference: 'path:with-colon.js:100' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should compare paths before line numbers', function() {
+      const unordered = {
+        a: { comments: { reference: 'path-a.js:20' } },
+        b: { comments: { reference: 'path-b.js:10' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should compare paths case-insensitively', function() {
+      const unordered = {
+        a: { comments: { reference: 'path-a.js:10' } },
+        b: { comments: { reference: 'path-B.js:10' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should treat reference with no colon as all path', function() {
+      const unordered = {
+        a: { comments: { reference: 'path-a.js' } },
+        b: { comments: { reference: 'path-b.js' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should treat reference with a colon suffix as all path', function() {
+      const unordered = {
+        a: { comments: { reference: 'path-a.js:' } },
+        b: { comments: { reference: 'path-b.js:' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should treat reference with a non-numeric part after the colon as all path', function() {
+      const unordered = {
+        a: { comments: { reference: 'path-a.js:not-a-number' } },
+        b: { comments: { reference: 'path-b.js:not-a-number' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'a');
+      assert(keys[1] === 'b');
+    });
+
+    it('Should compare references line by line', function() {
+      const unordered = {
+        a: { comments: { reference: 'path.js:20\npath.js:820' } },
+        b: { comments: { reference: 'path.js:20\npath.js:453' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'b');
+      assert(keys[1] === 'a');
+    });
+
+    it('Should sort the reference with more lines first if common lines are all equal', function() {
+      const unordered = {
+        a: { comments: { reference: 'path.js:20\npath.js:30' } },
+        b: { comments: { reference: 'path.js:20\npath.js:30\npath.js:40' } },
+      };
+
+      const ordered = utils.sortObjectKeysByRef(unordered);
+      const keys = Array.from(Object.keys(ordered));
+      assert(keys[0] === 'b');
+      assert(keys[1] === 'a');
     });
   });
 });


### PR DESCRIPTION
So that "source-file.js:20" appears before "source-file.js:100".
Also sort references line by line, so that e.g.

path.js:122
path.js:98

is now written as

path.js:98
path.js:122

and sorted after path.js:90 and before path.js:100.

For a real-life example of how this change looks, see [this commit diff](https://github.com/loot/loot/commit/ed69f5c9a09f3ce1e42980a9fc4b627736ccc056#diff-5851e036d6c90e7507edc8bac6b9d480).